### PR TITLE
Feature/step1 save password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+RUN yes | unminimize
+RUN apt-get update && \
+    apt-get install -y man locales vim tmux less 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata 
+RUN locale-gen ja_JP.UTF-8
+RUN echo "export LANG=ja_JP.UTF-8" >> ~/.bashrc
+ENV LANG=ja_JP.UTF-8
+ENV TZ=Asia/Tokyo
+WORKDIR /PASSWORD_MANAGER

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# パスワードマネージャー
+アプレンティスの課題「パスワードマネージャー」
+
+## 起動方法
+
+### Dockerの設定
+- Dockerfileとcompose.ymlに記述を行う。
+- Dockerアプリを起動
+
+### イメージのビルドを行う
+```
+docker compose up -d
+```
+
+### パスワードマネージャー実行
+コンテナ内に入る
+```
+docker compose exec app bash
+```
+
+実行権限付与
+```
+chmod 777 ./password_manager.sh
+```
+
+実行
+```
+./password_manager.sh
+```
+
+## 参考
+- [アプレンティスパスワードマネージャー課題](https://github.com/APPRENTICE-jp/apprentice-challenge/blob/12th/quest/linux/PASSWORD_MANAGER.md)
+- [Docker Linux環境構築](https://zenn.dev/bloomer/articles/5fd4e929fdb77a)

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,6 @@
+services:
+  app:
+    build: .
+    tty: true
+    volumes:
+      - .:/PASSWORD_MANAGER

--- a/information.txt
+++ b/information.txt
@@ -1,0 +1,1 @@
+service:user:password

--- a/password_manager.sh
+++ b/password_manager.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo "パスワードマネージャーへようこそ！"
+read -p "サービス名を入力してください： " servicename
+read -p "ユーザー名を入力してください： " username
+read -p "パスワードを入力してください： " password
+echo "$servicename:$username:$password" >> information.txt
+echo "Thank you!"


### PR DESCRIPTION
# 基本のパスワード保存処理を実装
アプレンティス課題[ステップ1](https://github.com/APPRENTICE-jp/apprentice-challenge/blob/12th/quest/linux/PASSWORD_MANAGER.md)を実装しました。

- シェルスクリプト実行
[![Image from Gyazo](https://i.gyazo.com/c7fc31f717cadcfd597b1b059127fcf4.png)](https://gyazo.com/c7fc31f717cadcfd597b1b059127fcf4)

- 保存確認
- [![Image from Gyazo](https://i.gyazo.com/cf4162d7c54f872e90e54b558e738198.png)](https://gyazo.com/cf4162d7c54f872e90e54b558e738198)

# その他
- README.md記述
- Docker設定